### PR TITLE
reallocate after repeated token fetch failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2924,6 +2924,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kelpie",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A worker binary to coordinate long running jobs on salad. Works with Kelpie API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -43,6 +43,8 @@ if (
 
 const maxRetries = parseInt(MAX_RETRIES, 10);
 const maxJobFailures = parseInt(MAX_JOB_FAILURES, 10);
+const MAX_TOKEN_FAILURES = 5;
+let tokenFailures = 0;
 const imdsUrl = "http://169.254.169.254";
 
 const headers: Record<string, string> = {
@@ -327,10 +329,21 @@ async function getSaladJWT(
       3,
       log
     );
+    tokenFailures = 0;
     const { header, payload } = decodeJWT(token);
     return { token, header, payload };
   } catch (e: any) {
+    tokenFailures++;
     log.error(e.message);
+    if (tokenFailures >= MAX_TOKEN_FAILURES) {
+      log.error(
+        `Failed to fetch workload instance token after ${tokenFailures} consecutive attempts`
+      );
+      await reallocateMe(
+        `Kelpie: Token unavailable after ${tokenFailures} consecutive attempts`,
+        log
+      );
+    }
     throw new Error("Failed to get token");
   }
 }


### PR DESCRIPTION
This pull request introduces improved error handling for repeated token fetch failures in the `src/api.ts` file and bumps the package version in `package.json`. The main change is to track consecutive token fetch failures and trigger a reallocation if a threshold is reached, improving reliability when the token service is unavailable.

**Error handling improvements:**

* Added a `tokenFailures` counter and `MAX_TOKEN_FAILURES` constant to track consecutive token fetch failures in `src/api.ts`. If fetching the token fails five times in a row, the worker logs an error and calls `reallocateMe` to trigger reallocation. The counter resets on a successful token fetch. [[1]](diffhunk://#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700R46-R47) [[2]](diffhunk://#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700R332-R346)

**Version update:**

* Bumped the package version from `0.7.1` to `0.7.2` in `package.json` to reflect these changes.